### PR TITLE
Increase version of typing-extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jetblack-serialization"
-version = "2.1.1"
+version = "2.1.2"
 description = "Serialization for JSON and XML using typing"
 repository = "https://github.com/rob-blackbourn/jetblack-serialization"
 authors = ["Rob Blackbourn <rob.blackbourn@gmail.com>"]
@@ -15,7 +15,7 @@ packages = [
 python = "^3.7"
 jetblack-iso8601 = "^1.0"
 lxml = "^4.4.2"
-typing-extensions = "^3.7"
+typing-extensions = "^4"
 typing_inspect = "^0.5.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
typing-extensions has started observing `semver`, as of major version 4.  Pinning the version in this library to be <3 stops downstream users from using newer typing features.